### PR TITLE
Bugfix: package-lock.json name prop out of date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "biotope-element",
+  "name": "@biotope/element",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
Fixed package name in package-lock.json file.