### PR TITLE
Bugfix: Props aren't updated when attributes change

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,7 @@ export default class BioElement<TProps extends object, TState> extends HyperHTML
   };
 
   attributeChangedCallback() {
-    this.render();
+    this.onPropsChanged();
   }
 
   get props(): TProps {


### PR DESCRIPTION
Fixed bug where props weren't being updated when attributes changed.

If a parent component wants to control the child's behaviour, it does so by changing its attributes. Without this change, the component props will not be updated when an attribute changes. It is then up to the component developer to merge that change into the state (if he/she wants to).