### PR TITLE
Feature: Attributes auto-merge

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,12 @@
 import HyperHTMLElement from 'hyperhtml-element';
 
+const parseAttribute = (value: string) => {
+  let parsedValue: string|number|object = value;
+  if (!isNaN(value as any)) {
+    parsedValue = +value;
+  }
+  return parsedValue;
+};
 
 export default class BioElement<TProps extends object, TState> extends HyperHTMLElement<TState> {
 

--- a/index.ts
+++ b/index.ts
@@ -12,16 +12,28 @@ export default class BioElement<TProps extends object, TState> extends HyperHTML
 
   private _props: TProps;
 
+  // overwrite if some attributes should be auto-merged to your props
   static get observedAttributes(): string[] {
     return [];
   };
 
-  attributeChangedCallback() {
-    this.onPropsChanged();
+  attributeChangedCallback(name: string, _: string, newValue: string): void {
+    this.props = {
+      ...(this.props as any),
+      [name]: parseAttribute(newValue),
+    };
+  }
+
+  // overwrite if you want default props in your component
+  get defaultProps(): TProps {
+    return null;
   }
 
   get props(): TProps {
-    return { ...(<any>this.defaultProps), ...(<any>this.propsFromAttributes), ...(<any>this._props) };
+    return {
+      ...(this.defaultProps as any),
+      ...(this._props as any),
+    };
   }
 
   set props(value) {
@@ -30,11 +42,13 @@ export default class BioElement<TProps extends object, TState> extends HyperHTML
   }
 
   get propsFromAttributes(): TProps {
-    return null;
-  }
-
-  get defaultProps(): TProps {
-    return null;
+    return BioElement.observedAttributes.reduce((collection: TProps, attributeName: string) => ({
+      ...(collection as any),
+      ...(this.hasAttribute(attributeName)
+        ? { [attributeName]: parseAttribute(this.getAttribute(attributeName)) }
+        : {}
+      ),
+    }), {}) as TProps;
   }
 
   // overwrite if you eg need to merge into your state

--- a/index.ts
+++ b/index.ts
@@ -1,13 +1,5 @@
 import HyperHTMLElement from 'hyperhtml-element';
 
-const parseAttribute = (value: string) => {
-  let parsedValue: string|number|object = value;
-  if (!isNaN(value as any)) {
-    parsedValue = +value;
-  }
-  return parsedValue;
-};
-
 const attributeName = (attr: string|BioAttribute) => typeof attr === 'string' ? attr : attr.name;
 
 export interface BioAttribute {
@@ -30,9 +22,7 @@ export default class BioElement<TProps extends object, TState> extends HyperHTML
     const attribute = BioElement.bioAttributes.find(attr => attributeName(attr) === newValue);
     this.props = {
       ...(this.props as any),
-      [name]: typeof attribute === 'string'
-        ? parseAttribute(newValue)
-        : attribute.converter(newValue),
+      [name]: typeof attribute === 'string' ? newValue : attribute.converter(newValue),
     };
   }
 


### PR DESCRIPTION
This proposed change solves the following:
 - If a parent component updates a BioElement attribute, the element receives the notification and updates it's props automatically

Notes:
 - numbers passed on attributes will be converted to numbers on props. strings will stay as is
 - `propsFromAttributes` is now only a helper for BioElement components as `attributeChangedCallback` now updates `_props`
 - added notes on all overridable functions