### PR TITLE
fixed implementation of attributeChangedCallback

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -35,7 +35,7 @@ export default abstract class BioElement<TProps extends object, TState> extends 
   };
 
   attributeChangedCallback(name: string, _: string, newValue: string): void {
-    const attribute = (<any>this.constructor).bioAttributes.find((attr: string|BioAttribute) => attributeName(attr) === name);
+    const attribute = (this.constructor as any).bioAttributes.find((attr: string|BioAttribute) => attributeName(attr) === name);
     this.props = {
       ...(this.props as any),
       [name]: typeof attribute === 'string' ? newValue : attribute.converter(newValue),

--- a/index.ts
+++ b/index.ts
@@ -35,7 +35,7 @@ export default abstract class BioElement<TProps extends object, TState> extends 
   };
 
   attributeChangedCallback(name: string, _: string, newValue: string): void {
-    const attribute = BioElement.bioAttributes.find(attr => attributeName(attr) === newValue);
+    const attribute = (<any>this.constructor).bioAttributes.find((attr: string|BioAttribute) => attributeName(attr) === name);
     this.props = {
       ...(this.props as any),
       [name]: typeof attribute === 'string' ? newValue : attribute.converter(newValue),


### PR DESCRIPTION
- compare with name of changed attribute
- use `bioAttributes` of current class (not always empty `BioElement.bioAttributes`)