### PR TITLE
Feature: Hyperhtml wire

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@biotope/element",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@biotope/element",
   "title": "Biotope Element",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "description": "Biotope Element",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/biotope/biotope-element#readme",
   "dependencies": {
     "dasherize": "^2.0.0",
+    "hyperhtml": "^2.13.0",
     "hyperhtml-element": "^2.1.1"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import HyperHTMLElement from 'hyperhtml-element';
+import HyperHTML from 'hyperhtml';
 import dasherize from 'dasherize';
 
 import { BioAttribute } from './types';
@@ -48,6 +49,10 @@ export default abstract class BioElement<TProps extends object, TState> extends 
   set props(value) {
     this._props = value;
     this.onPropsChanged();
+  }
+
+  get wire() {
+    return HyperHTML.wire(this);
   }
 
   // overwrite if you eg need to merge into your state


### PR DESCRIPTION
Since we are going to need at least an "if" logic on our templates:
```jsx
return this.html`
  <div>
    ${this.haveCoffee ? '<div>Hurray! We have coffee!</div>' : ''}
  </div>
`;
```
and HyperHTML doesn't support this out of the box with the `this.html` function (because the div will be written as text and not as html), we are going to need to use the `hyperHtml.wire` function like so:
```jsx
import hyperhtml from 'hyperhtml';
...
return this.html`
  <div>
    ${this.haveCoffee ? hyperhtml.wire(this)`<div>Hurray! We have coffee!</div>` : ''}
  </div>
`;
```

To do this seamlessly and without end-users (developers) having to import `hyperhtml`, I propose this change (this PR), which will enable our components to use `wire` the same way we use `this.html`:
```jsx
return this.html`
  <div>
    ${this.haveCoffee ? this.wire`<div>Hurray! We have coffee!</div>` : ''}
  </div>
`;
```