### PR TITLE
Fix es5 polyfill isRegistered error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@biotope/element",
   "title": "Biotope Element",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Biotope Element",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/src/is-registered.ts
+++ b/src/is-registered.ts
@@ -1,8 +1,8 @@
 
 export const isRegistered = (name: string) => {
-  switch (document.createElement(name).constructor) {
-    case HTMLElement: return false;
-    case HTMLUnknownElement: return false;
+  switch (document.createElement(name).constructor.name) {
+    case 'HTMLElement': return false;
+    case 'HTMLUnknownElement': return false;
   }
   return true;
 };


### PR DESCRIPTION
As the es5 shim HTMLElement !== the vanilla HTMLElement, we need to use the name of the function instead