### PR TITLE
Feature: Add emit feature

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,16 @@ export default abstract class Component<TProps extends object, TState> extends H
     };
   }
 
+  protected emit<T>(name: string, detail?: T, addPrefix: boolean = true) {
+    return this.dispatchEvent(new CustomEvent(
+      `${addPrefix ? `${(this.constructor as typeof Component).componentName}-` : ''}${name}`,
+      {
+        bubbles: true,
+        ...(detail ? { detail } : {}),
+      },
+    ));
+  }
+
   // overwrite if you want default props in your component
   get defaultProps(): TProps {
     return null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ export default abstract class Component<TProps extends object, TState> extends H
       `${addPrefix ? `${(this.constructor as typeof Component).componentName}-` : ''}${name}`,
       {
         bubbles: true,
-        ...(detail ? { detail } : {}),
+        ...(detail !== undefined ? { detail } : {}),
       },
     ));
   }


### PR DESCRIPTION
Description:
function that emits a custom event with the name of the component prefixed (by default) and any given information.
Examples:
```typescript
// <x-test-component />
this.emit('toggle');
// emits a bubbled event called "x-test-component-toggle"
// with no info attached
```
```typescript
// <x-test-component />
this.emit('toggle', 'pass this to any parent pls');
// emits a bubbled event called "x-test-component-toggle"
// with "pass this to any parent pls" attached in the "detail" property
```
```typescript
// <x-test-component />
this.emit('toggle', { value: 'YAY' }, false);
// emits a bubbled event called "toggle"
// with "{ value: 'YAY' }" attached in the "detail" property
```