### PR TITLE
Feature: Attribute types

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,10 +1,11 @@
 # Advanced
 
 ## Handling state
-Every component can have its own internal state. To set the state just call the `setState` function of the component. To use the state just use `this.state`.
-```js
-import Component from '@biotope/element';
+Every component can have its own internal state. To set the state just call the `setState` function
+of the component. To use the state just use `this.state`.
 
+```javascript
+import Component from '@biotope/element';
 
 class MyButton extends Component {
   get defaultState() {
@@ -12,27 +13,29 @@ class MyButton extends Component {
       powermode: 'off'
     }
   }
+
   connectedCallback() {
     this.addEventListener('click', this.onclick);
   }
+
   onclick() {
     // this will set the state on click
     this.setState({
-      powermode: "on"
+      powermode: 'on',
     });
   }
 
   render() {
     return this.html`
-      Powermode ${this.state.powermode}
+      Powermode ${this.state.powermode}!
     `;
   }
 }
 
 MyButton.componentName = 'my-button';
-
 MyButton.register();
 ```
+
 ```html
 <my-button></my-button>
 ```
@@ -44,30 +47,31 @@ Result:
 </my-button>
 ```
 
-
-
 ## Dependencies
-Your component may need some other components to work. To allow the components to be registered when you need them, you can define dependencies for every component:
+Your component may need some other components to work. To allow the components to be registered when
+you need them, you can define dependencies for every component:
 
-```typescript
+```javascript
 // typescript
 import Component from '@biotope/element';
 
 class XSlide extends Component {
-  static componentName = 'x-slide';
+  public static componentName = 'x-slide';
 
-  render() {
+  public render(): HTMLElement {
     return this.html``;
   }
 }
 
 class XSlider extends Component {
-  // Here the slider needs the slides to display correctly
-  static dependencies = [XSlide as typeof Component];
+  public static componentName = 'x-slider';
 
-  static componentName = 'x-slider';
+  public static dependencies = [
+    // Here the slider needs the slides to display correctly
+    XSlide as typeof Component,
+  ];
 
-  render() {
+  public render() {
     return this.html`
       <x-slide></x-slide>
     `;
@@ -78,44 +82,40 @@ class XSlider extends Component {
 XSlider.register();
 ```
 
-
-
-
-
-
 ## Nesting components
 You can also nest components inside the html and use the `children` accessor to get them in the root
 component and manipulate them.
 
-
-```typescript
+```javascript
 // typescript
 import Component from '@biotope/element';
 
 class XSlide extends Component {
-  static componentName = 'x-slide';
+  public static componentName = 'x-slide';
 
-  render() {
+  public render() {
     return this.html``;
   }
 }
 
 class XSlider extends Component {
-  static dependencies = [XSlide as typeof Component];
+  public static componentName = 'x-slider';
 
-  static componentName = 'x-slider';
+  public static dependencies = [
+    XSlide as typeof Component,
+  ];
 
-  render() {
+  public render() {
     // Here we use this.children to access the three child x-slides
-    const slides = this.children.map(el => 'Slide');
     return this.html`
-      ${slides}
+      ${this.children.map(child => 'Slide')}
     `;
   }
 }
 
 XSlider.register();
 ```
+
 ```html
 <x-slider>
   Slide

--- a/docs/component.md
+++ b/docs/component.md
@@ -2,7 +2,7 @@
 
 ## The concept of a component
 
-We trust in the web.  
+We trust in the web.
 
 That's why we decided to write biotope and the biotope element with mostly vanilla web technologies
 and polyfill it untill the right time is there.
@@ -16,24 +16,23 @@ documentation.
 
 A component is a collection of functionality which could be reused.
 
-
 ## render()
 As you can see in the hello world example every component implements a `render` function. In there
 you can call `this.html` function on a template literal to add it to the components root:
 
-```js
-// javascript
+```javascript
 import Component from '@biotope/element';
 
 class MyButton extends Component {
   render() {
     // this will add 'Hello World' to the root of the element
-    return this.html`Hello World 🐤`;
+    return this.html`
+      Hello World 🐤
+    `;
   }
 }
 
 MyButton.componentName = 'my-button';
-
 MyButton.register();
 ```
 
@@ -41,34 +40,34 @@ In the template literal you can also add valid html code as well as the `<slot>`
 current content of the component will be placed. Read more about it in the [shadow dom](#shadow-dom)
 section.
 
-
 ## props
 Every component has its own props. The props can be passed into the component two ways:
 
 You can use attributes or set the props via javascript:
 
-
 ### defaultProps
 To give your props a default value you have to set the `defaultProps` getter of the component:
-```js
+```javascript
 import Component from '@biotope/element';
 
 class MyButton extends Component {
   protected get defaultProps() {
     return {
-      foo: 'bar'
+      foo: 'bar',
     };
   }
 
   render() {
-    return this.html`🎰 ${this.props.foo}`;
+    return this.html`
+      🎰 ${this.props.foo}
+    `;
   }
 }
 
 MyButton.componentName = 'my-button';
-
 MyButton.register();
 ```
+
 ```html
 <my-button></my-button>
 ```
@@ -79,33 +78,31 @@ This will result in the following html:
 <my-button>🎰 bar</my-button>
 ```
 
-
-
 ### setting props
 You can set the props of a component after initialisation by accessing its instance like this:
 ```html
 <my-button id="foo"></my-button>
 ```
-```js
+
+```javascript
 document.getElementById('foo').props = {
   foo: 'bar'
 }
 ```
+
 Changing the props this way will trigger the render method.
 
-
-
-
-
-## attributes
+## Attributes
 To pass in data to a component attributes on the html tag can be used:
+
 ```html
 <my-button foo="bar"><my-button>
 ```
 
 To pass these values to the props object, you have to define the corresponding attribute in the
 component:
-```js
+
+```javascript
 import Component from '@biotope/element';
 
 class MyButton extends Component {
@@ -122,22 +119,24 @@ MyButton.register();
 
 This will take care of the attributes value and pass it to the props of the component:
 
-```js
+```javascript
 import Component from '@biotope/element';
 
 class MyButton extends Component {
   render() {
-    return this.html`${this.props.foo} 🌸`;
+    return this.html`
+      ${this.props.foo} 🌸
+    `;
   }
 }
 
 MyButton.componentName = 'my-button';
 MyButton.attributes = ['foo'];
-
 MyButton.register();
 ```
 
 This will result in the following html:
+
 ```html
 <my-button foo="bar">
   bar 🌸
@@ -151,64 +150,73 @@ If your attributes get more complex, you might want to have multi word names lik
 To access those attributes in the props, you have to use the camelCase version of the string. In our
 example this will be `aComplexAttribute`
 
-```js
+```javascript
 import Component from '@biotope/element';
 
 class MyButton extends Component {
   render() {
-    return this.html`${this.props.anotherAttribute} 🌸`;
+    return this.html`
+      ${this.props.anotherAttribute} 🌸
+    `;
   }
 }
 
 MyButton.componentName = 'my-button';
 MyButton.attributes =  ['another-attribute'];
-
 MyButton.register();
 ```
 
 This will result in the following html:
+
 ```html
 <my-button another-attribute="Some simple value">
   Some simple value 🌸
 <my-button>
 ```
 
-
-
-
-
-
-
-
-
-
 ### Transforming attributes
 When you set values in the html tags attributes, these values will always be strings. If you pass
-other data types through the attributes, you also have to take care of their transformation. You can
-do this by setting a attribute converter in the attributes array instead of a simple string.
+other data types through the attributes, something has to take care of their transformation. You can
+do this by setting an attribute type or a custom converter function in the attributes array instead
+of a simple string.
 
-#### Numbers
+Attribute types are pre-defined conversion functions made available to developers so that you can
+write more code that matters to your application and less code to parse strings. The types we offer
+are `string`, `number`, `boolean`, `object` and `array`.
+Take note that all of them will try to force the conversion. For example, if an attribute like
+`'["a", "b"]'` is forced to an `object` type, it will be converted to `{0: 'a', 1: 'b'}`.
+
+#### Example: Numbers
 ```html
 <my-button fooNum="5"><my-button>
 ```
-```js
+
+```javascript
 import Component from '@biotope/element';
 
 class MyButton extends Component {
   render() {
     // foo will now be a number
-    return this.html`🚀 ${typeof this.props.fooNum}`;
+    return this.html`
+      🚀 ${typeof this.props.fooNum}
+    `;
   }
 }
 
 MyButton.componentName = 'my-button';
-// here we use the converter function
+// use our pre-defined converters
+MyButton.attributes = [{
+  name: 'fooNum',
+  type: 'number',
+}];
+// OR use your custom converter function
 MyButton.attributes = [{
   name: 'fooNum',
   converter: (value) => parseInt(value, 10),
 }];
 
 MyButton.register();
+
 ```
 This will result in the following html:
 ```html
@@ -217,54 +225,57 @@ This will result in the following html:
 <my-button>
 ```
 
-#### Booleans
+#### Example: Booleans
 Passing in booleans is handled similarly, but instead of adding an string attribute you either add
 the attribute or not. So your initial element might look like this:
+
 ```html
 <my-button primary><my-button>
 ```
-In this case foo-bool equals true, when not passing in the attribute at all it equals false.
+
+In this case "primary" equals true, when not passing in the attribute at all it equals false.
 If your script looks like this...
 
-```js
+```javascript
 import Component from '@biotope/element';
 
 class MyButton extends Component {
   render() {
     const { primary } = this.props;
     // primary will now be a boolean
-    return this.html`💼 ${primary ? 'hello': 'goodbye'}`;
+    return this.html`
+      💼 ${primary ? 'hello': 'goodbye'} ${typeof primary}
+    `;
   }
 }
 
 MyButton.componentName = 'my-button';
 MyButton.attributes = [{
   name: 'primary',
-  converter: () => true,
+  type: 'boolean',
 }];
-
 MyButton.register();
 ```
+
 ...it will result in the following HTML:
 
 ```html
 <my-button primary>
-  💼 hello
+  💼 hello boolean
 <my-button>
 ```
 
-> Note: You can get a list of the observed attributes by using the components
-`this.observedAttributes` property
-
 ## Shadow dom
 Every component extending the biotope element is using shadow dom. This will help you to not mess up
-our existing component structure. If have the following html and js:
+our existing component structure. If you have the following html and js:
+
 ```html
 <my-button>
   I am a little 🦋
 <my-button>
 ```
-```js
+
+```javascript
 import Component from '@biotope/element';
 
 class MyButton extends Component {
@@ -278,11 +289,11 @@ class MyButton extends Component {
 }
 
 MyButton.componentName = 'my-button';
-
 MyButton.register();
 ```
 
 It would result in this html:
+
 ```html
 <my-button>
   I am a little 🦋

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,18 +1,16 @@
 # Events
-Events are for communication of your 
-components to the outside world.
-There is nothing different from normal 
-javascript events here. We just have some 
-guidelines which may help you using 
-biotope-element with events.
+Events are for communication of your components to the outside world.
+There is nothing different from normal javascript events here.
+We just have some guidelines which may help you using biotope-element with events.
 
 ## Definition
 To prevent typos in your events, we encourage you to define you events as constants and always
 reference it instead of just using a string:
-```js
+
+```javascript
 const MY_BUTTON_EVENTS = {
-  PRESSED: 'pressed'
-}
+  PRESSED: 'pressed',
+};
 
 export default MY_BUTTON_EVENTS;
 ```
@@ -26,7 +24,7 @@ care.
 
 To dispatch an event you can just call `emit` on the component:
 
-```js
+```javascript
 import Component from '@biotope/element';
 import MY_BUTTON_EVENTS from './events';
 
@@ -34,7 +32,7 @@ class MyButton extends Component {
   constructor() {
     super();
     // we have to bind the callback to accesss this inside the function
-    this.onclick = this.onclick.bind(this)
+    this.onclick = this.onclick.bind(this);
   }
 
   render() {
@@ -46,12 +44,11 @@ class MyButton extends Component {
   }
 
   onclick(event) {
-    this.emit(MY_BUTTON_EVENTS.PRESSED)
+    this.emit(MY_BUTTON_EVENTS.PRESSED);
   }
 }
 
 MyButton.componentName = 'my-button';
-
 MyButton.register();
 ```
 
@@ -59,7 +56,7 @@ MyButton.register();
 Now to listen to these custom events, you can just pass a function to an attribute with the same
 name as your event. The function you pass should bind `this` so we can access the component inside:
 
-```js
+```javascript
 import Component from '@biotope/element';
 import MY_BUTTON_EVENTS from '../MyButton/events';
 
@@ -77,7 +74,6 @@ class ImageStage extends Component {
 }
 
 ImageStage.componentName = 'image-stage';
-
 ImageStage.register();
 ```
 

--- a/docs/guide-data-channels.md
+++ b/docs/guide-data-channels.md
@@ -31,7 +31,7 @@ convenient to set this data by javascript.
 <custom-element attribute-1="a string" attribute-2="true"></custom-element>
 ```
 
-```js
+```javascript
 // Such nice!
 document.querySelector('custom-element').props = {
   'attribute-3': [
@@ -47,6 +47,7 @@ document.querySelector('custom-element').props = {
 ## Slotting content
 In case you want to pass HTML markup to the component, we recommend slotting it and handle it
 externally:
+
 ```html
 <!-- Clean! -->
 <custom-element>

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -2,70 +2,85 @@
 
 ## Installation
 You can install the biotope element in your project using npm
+
 ```bash
 npm install @biotope/element --save
 ```
+
 or yarn
+
 ```bash
 yarn add @biotope/element
 ```
 
 ## Create  your first component
 First import the element in your component:
-```js
+
+```javascript
 import Component from '@biotope/element';
 ```
 
 Then you extend your component with the biotope element:
-```js
+
+```javascript
 class HelloWorldComponent extends Component {
   render() {
-    return this.html`Hello World 🐤`;
+    return this.html`
+      Hello World 🐤
+    `;
   }
 }
 
-// needed if you uglify your code, which is most likely
+// needed if you transpile to es5 and uglify your code at the same time
 HelloWorldComponent.componentName = 'hello-world';
 ```
 
-```typescript
+```javascript
+// typescript
 class HelloWorldComponent extends Component {
-  // needed if you uglify your code, which is most likely
-  static componentName = 'hello-world';
+  // needed if you transpile to es5 and uglify your code at the same time
+  public static componentName = 'hello-world';
 
-  render() {
-    return this.html`Hello World 🐤`;
+  public render() {
+    return this.html`
+      Hello World 🐤
+    `;
   }
 }
 ```
+
 > Notice the `static componentName` part. This has to be set AND it should be written in kebab-case.
 
 After defining the class, you have to call the `register` function on it, to use it in HTML:
-```js
+
+```javascript
 HelloWorldComponent.register();
 ```
 
 So the whole file will look like this:
-```js
+```javascript
 import Component from '@biotope/element';
 
 class HelloWorldComponent extends Component {
   render() {
-    return this.html`Hello World 🐤`;
+    return this.html`
+      Hello World 🐤
+    `;
   }
 }
 
 HelloWorldComponent.componentName = 'hello-world';
-
 HelloWorldComponent.register();
 ```
 
 After that you can use it in your html like that:
+
 ```html
 <my-button></my-button>
 ```
 
 This will result in the following html:
+
 ```html
 <my-button>
   Hello world 🐤

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -3,7 +3,8 @@
 ## Adding styles
 As every component uses shadow dom by default, you have to put the styles inside the shadow root.
 You can either write inline styles:
-```js
+
+```javascript
 import Component from '@biotope/element';
 
 class MyButton extends Component {
@@ -20,12 +21,12 @@ class MyButton extends Component {
 }
 
 MyButton.componentName = 'my-button';
-
 MyButton.register();
 ```
 
 or import your css from an external file with some kind of bundler:
-```js
+
+```javascript
 import Component from '@biotope/element';
 import style from './styles.css';
 
@@ -39,7 +40,6 @@ class MyButton extends Component {
 }
 
 MyButton.componentName = 'my-button';
-
 MyButton.register();
 ```
 

--- a/docs/used-with.md
+++ b/docs/used-with.md
@@ -3,7 +3,9 @@
 ## Biotope Resource Loader
 The [biotope-resource-loader](https://github.com/biotope/biotope-resource-loader) makes it easy for
 you to load the components you built with biotope-element like so:
+
 ```html
 <my-button data-resources="[{paths: ['path/to/js/my-button.js']}]"></my-button>
 ```
+
 This will load the script and attatch it to the dom.

--- a/examples/src/js/loops-props-and-state/index.html
+++ b/examples/src/js/loops-props-and-state/index.html
@@ -18,6 +18,10 @@
     ></example-table>
     <br />
     <example-table
+      converted-attribute='two'
+    ></example-table>
+    <br />
+    <example-table
       show-counter
     ></example-table>
   </body>

--- a/examples/src/js/loops-props-and-state/index.js
+++ b/examples/src/js/loops-props-and-state/index.js
@@ -74,17 +74,20 @@ ExampleTable.attributes = [
   'simple-text',
   {
     name: 'complex-attribute',
+    type: 'array',
+  },
+  {
+    name: 'converted-attribute',
     converter(prop) {
-      try {
-        return JSON.parse(prop || '');
-      } catch (_) {
-        return [];
+      if (prop === 'one') {
+        return 1;
       }
+      return prop === 'two' ? 2 : 0;
     },
   },
   {
     name: 'show-counter',
-    converter: prop => !!prop || typeof prop === 'string',
+    type: 'boolean',
   },
 ];
 ExampleTable.register();

--- a/examples/src/ts/loops-props-and-state/index.html
+++ b/examples/src/ts/loops-props-and-state/index.html
@@ -18,6 +18,10 @@
     ></example-table>
     <br />
     <example-table
+      converted-attribute='two'
+    ></example-table>
+    <br />
+    <example-table
       show-counter
     ></example-table>
   </body>

--- a/examples/src/ts/loops-props-and-state/index.ts
+++ b/examples/src/ts/loops-props-and-state/index.ts
@@ -9,6 +9,7 @@ export interface ExampleTableProps {
   showCounter: boolean;
   simpleText?: string;
   complexAttribute?: string[];
+  convertedAttribute?: number;
 }
 
 interface ExampleTableState {
@@ -22,17 +23,20 @@ export class ExampleTable extends Component<ExampleTableProps, ExampleTableState
     'simple-text',
     {
       name: 'complex-attribute',
-      converter(prop?: string): string[] {
-        try {
-          return JSON.parse(prop || '');
-        } catch (_) {
-          return [];
+      type: 'array',
+    },
+    {
+      name: 'converted-attribute',
+      converter(prop?: string): number {
+        if (prop === 'one') {
+          return 1;
         }
+        return prop === 'two' ? 2 : 0;
       },
     },
     {
       name: 'show-counter',
-      converter: (prop?: string): boolean => !!prop || typeof prop === 'string',
+      type: 'boolean',
     },
   ];
 

--- a/src/attribute-mapper.ts
+++ b/src/attribute-mapper.ts
@@ -1,9 +1,65 @@
-import { Attribute } from './types';
+import { Attribute, TypedAttribute, ConvertableAttribute } from './types';
 
 export const attributeName = (attribute: string | Attribute): string => (
   typeof attribute === 'string' ? attribute : attribute.name
 );
 
-export const attributeValue = (attribute: string | Attribute, value?: string): string => (
-  typeof attribute === 'string' ? value : attribute.converter(value)
-);
+const arrayReducer = <T>(accumulator: T[], key: string, _: number, original: object): T[] => ([
+  ...accumulator,
+  original[key],
+]);
+
+const objectReducer = (accumulator: object, key: string, _: number, original: object): object => ({
+  ...accumulator,
+  [key]: original[key],
+});
+
+const jsonParse = (value: string, type: 'array' | 'object'): object => {
+  let parsedValue: object;
+  try {
+    parsedValue = JSON.parse(value);
+  } catch (_) {
+    parsedValue = undefined;
+  }
+
+  const reducerFunction = type === 'array' ? arrayReducer : objectReducer;
+  const reducerStarter = type === 'array' ? [] : {};
+
+  parsedValue = typeof parsedValue !== 'object' ? null : Object.keys(parsedValue)
+    .reduce(reducerFunction, reducerStarter);
+
+  return parsedValue;
+};
+
+export const attributeValue = (
+  attribute: string | Attribute,
+  value?: string,
+): string | boolean | object | number => {
+  if (typeof attribute === 'string') {
+    return value;
+  }
+
+  if ((attribute as ConvertableAttribute).converter) {
+    return (attribute as ConvertableAttribute).converter(value);
+  }
+
+  let convertedValue: string | boolean | object | number;
+  switch ((attribute as TypedAttribute).type) {
+    case 'array':
+      convertedValue = jsonParse(value, 'array');
+      break;
+    case 'object':
+      convertedValue = jsonParse(value, 'object');
+      break;
+    case 'boolean':
+      convertedValue = (!!value && value !== 'false') || value === '';
+      break;
+    case 'number':
+      convertedValue = +value;
+      break;
+    default:
+      convertedValue = value;
+      break;
+  }
+  return convertedValue;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,17 @@
 
-export interface Attribute {
+export interface SimpleAttribute {
   name: string;
+}
+
+export interface TypedAttribute extends SimpleAttribute {
+  type: 'object' | 'array' | 'boolean' | 'number' | 'string';
+}
+
+export interface ConvertableAttribute extends SimpleAttribute {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   converter: (prop?: string) => any;
 }
+
+export type Attribute = SimpleAttribute | TypedAttribute | ConvertableAttribute;
 
 export type HTMLElementContent = string | { toString: () => string };

--- a/tests/attribute-mapper.spec.ts
+++ b/tests/attribute-mapper.spec.ts
@@ -1,8 +1,8 @@
 import { attributeName, attributeValue } from '../src/attribute-mapper';
-import { Attribute } from '../src/types';
+import { ConvertableAttribute, TypedAttribute } from '../src/types';
 
 describe('attribute-mapper', (): void => {
-  const mockAttribute: Attribute = {
+  const mockAttribute: ConvertableAttribute = {
     name: 'mock-attribute',
     converter(value: string): string {
       return value;
@@ -33,10 +33,167 @@ describe('attribute-mapper', (): void => {
       });
     });
 
-    describe('given an Attribute', (): void => {
+    describe('given an ConvertableAttribute', (): void => {
       it('returns the converted value', (): void => {
         const result = attributeValue(mockAttribute, 'mock-value');
         expect(result).toBe('mock-value');
+      });
+    });
+
+    describe('given an TypedAttribute', (): void => {
+      describe('as string', (): void => {
+        const mockStringAttribute: TypedAttribute = {
+          name: 'mock-attribute',
+          type: 'string',
+        };
+
+        it('returns the value as is', (): void => {
+          const result = attributeValue(mockStringAttribute, 'mock-value');
+          expect(result).toBe('mock-value');
+        });
+
+        it('returns undefined', (): void => {
+          const result = attributeValue(mockStringAttribute, undefined);
+          expect(result).toBe(undefined);
+        });
+      });
+
+      describe('as number', (): void => {
+        const mockNumberAttribute: TypedAttribute = {
+          name: 'mock-attribute',
+          type: 'number',
+        };
+
+        it('parses a simple number', (): void => {
+          const result = attributeValue(mockNumberAttribute, '9');
+          expect(result).toBe(9);
+        });
+
+        it('parses a negative number', (): void => {
+          const result = attributeValue(mockNumberAttribute, '-9');
+          expect(result).toBe(-9);
+        });
+
+        it('parses a float', (): void => {
+          const result = attributeValue(mockNumberAttribute, '10.10');
+          expect(result).toBe(10.10);
+        });
+
+        it('parses a hexadecimal number', (): void => {
+          const result = attributeValue(mockNumberAttribute, '0x10');
+          expect(result).toBe(16);
+        });
+
+        it('parses a hexadecimal number', (): void => {
+          const result = attributeValue(mockNumberAttribute, '0');
+          expect(result).toBe(0);
+        });
+
+        it('parses a number with units', (): void => {
+          const result = attributeValue(mockNumberAttribute, '11px');
+          expect(result).toBe(11);
+        });
+
+        it('parses a number with padding and units', (): void => {
+          const result = attributeValue(mockNumberAttribute, '  12px ');
+          expect(result).toBe(12);
+        });
+
+        it('does not parse a value staring with a letter', (): void => {
+          const result = attributeValue(mockNumberAttribute, 'a13');
+          expect(result).toBeNaN();
+        });
+
+        it('does not parse undefined', (): void => {
+          const result = attributeValue(mockNumberAttribute, undefined);
+          expect(result).toBeNaN();
+        });
+      });
+
+      describe('as boolean', (): void => {
+        const mockBooleanAttribute: TypedAttribute = {
+          name: 'mock-attribute',
+          type: 'boolean',
+        };
+
+        it('parses an attribute with no value', (): void => {
+          const result = attributeValue(mockBooleanAttribute, '');
+          expect(result).toBe(true);
+        });
+
+        it('parses an attribute with "true"', (): void => {
+          const result = attributeValue(mockBooleanAttribute, 'true');
+          expect(result).toBe(true);
+        });
+
+        it('parses an attribute with jiberish', (): void => {
+          const result = attributeValue(mockBooleanAttribute, 'xrdctfvybgu');
+          expect(result).toBe(true);
+        });
+
+        it('parses an attribute with "false"', (): void => {
+          const result = attributeValue(mockBooleanAttribute, 'false');
+          expect(result).toBe(false);
+        });
+
+        it('parses an attribute with undefined', (): void => {
+          const result = attributeValue(mockBooleanAttribute, undefined);
+          expect(result).toBe(false);
+        });
+      });
+
+      describe('as object', (): void => {
+        const mockObjectAttribute: TypedAttribute = {
+          name: 'mock-attribute',
+          type: 'object',
+        };
+
+        it('parses an attribute with no value', (): void => {
+          const result = attributeValue(mockObjectAttribute, '');
+          expect(result).toEqual(null);
+        });
+
+        it('parses an attribute with undefined', (): void => {
+          const result = attributeValue(mockObjectAttribute, undefined);
+          expect(result).toBe(null);
+        });
+
+        it('parses an attribute with an object', (): void => {
+          const result = attributeValue(mockObjectAttribute, '{"a": "b"}');
+          expect(result).toEqual({ a: 'b' });
+        });
+
+        it('parses an attribute with an array', (): void => {
+          const result = attributeValue(mockObjectAttribute, '["a", "b"]');
+          expect(result).toEqual({ 0: 'a', 1: 'b' });
+        });
+      });
+
+      describe('as array', (): void => {
+        const mockArrayAttribute: TypedAttribute = {
+          name: 'mock-attribute',
+          type: 'array',
+        };
+
+        it('parses an attribute with no value', (): void => {
+          const result = attributeValue(mockArrayAttribute, '');
+          expect(result).toEqual(null);
+        });
+
+        it('parses an attribute with undefined', (): void => {
+          const result = attributeValue(mockArrayAttribute, undefined);
+          expect(result).toBe(null);
+        });
+
+        it('parses an attribute with an object', (): void => {
+          const result = attributeValue(mockArrayAttribute, '{"a": "b"}');
+          expect(result).toEqual(['b']);
+        });
+
+        it('parses an attribute with an array', (): void => {
+          const result = attributeValue(mockArrayAttribute, '["a", "b"]');
+          expect(result).toEqual(['a', 'b']);
+        });
       });
     });
   });


### PR DESCRIPTION
We can now use
```javascript
attributes: [
  { name: 'text', type: 'array' }
]
```
to force conversion to the given type. Or still use the custom converter
```javascript
attributes: [
  { name: 'text', converter() { ... } }
]
```

Still missing:
- [x] docs
- [x] tests
