### PR TITLE
Bugfix: Setting default attributes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,11 +78,6 @@ export default abstract class Component<TProps = object, TState = object> extend
     const postFunction = (): void => this.rendered();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.render = createRender(this as any, this.render.bind(this), postFunction);
-
-    // eslint-disable-next-line no-underscore-dangle
-    this.__initCallStack = [(): HTMLElement => this.render()];
-    // eslint-disable-next-line no-underscore-dangle
-    this.__initAttributesCallStack = [];
   }
 
   /* istanbul ignore next */

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,9 +59,9 @@ export default abstract class Component<TProps = object, TState = object> extend
 
   private __html: Renderer<HTMLElement>;
 
-  private __initCallStack: (() => void)[];
+  private __initCallStack: (() => void)[] = [];
 
-  private __initAttributesCallStack: (() => void)[];
+  private __initAttributesCallStack: (() => void)[] = [];
 
   public static register(silent = true): boolean {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/register.ts
+++ b/src/register.ts
@@ -59,6 +59,7 @@ export const register = (context: ComponentType, silent: boolean): boolean => {
   context.prototype.connectedCallback = function (): void {
     const instance = (this as ComponentInstance);
     instance.__initCallStack.unshift((): void => originalConnectedCallback.bind(instance)());
+    instance.__initAttributesCallStack.unshift((): HTMLElement => instance.render());
 
     resolveCallStack(instance, '__initCallStack');
     resolveCallStack(instance, '__initAttributesCallStack');

--- a/tests/register.spec.ts
+++ b/tests/register.spec.ts
@@ -30,6 +30,7 @@ describe('#register', (): void => {
         props: { first: 1, andSecond: 2 },
         connectedCallback: mockFunction,
         attributeChangedCallback: mockFunction,
+        render: mockFunction,
         __initCallStack: [mockDependency.register],
         __initAttributesCallStack: [mockDependency.register],
       },

--- a/tests/rendered.spec.ts
+++ b/tests/rendered.spec.ts
@@ -1,6 +1,5 @@
 /* eslint-disable max-classes-per-file */
 import Component from '../src';
-import { ComponentInstance } from '../src/internal-types';
 
 describe('#rendered', () => {
   let element;
@@ -28,15 +27,6 @@ describe('#rendered', () => {
     it('triggers the rendered method', (done) => setTimeout(() => {
       expect(mockRendered.mock.calls).toHaveLength(1);
       done();
-    }));
-
-    it('has a rrender method awaiting resolution', (done) => setTimeout(() => {
-      // eslint-disable-next-line no-underscore-dangle
-      (element as ComponentInstance).__initCallStack[0]();
-      setTimeout(() => {
-        expect(mockRendered.mock.calls).toHaveLength(2);
-        done();
-      });
     }));
   });
 


### PR DESCRIPTION
When setting a new attribute at startup:
- If the value of the attribute was equal to the default value for that same attribute, the component would not do the first render (because of the "equal values => no new render" optimiztion)
