### PR TITLE
Bugfix: Prevent re-renders on style

### DIFF
--- a/examples/src/js/styled/index.js
+++ b/examples/src/js/styled/index.js
@@ -13,7 +13,7 @@ class ExampleButton extends Component {
           font-size: var(--base-font-size);
           background: transparent;
           border-radius: 3px;
-          border: 2px solid blue;
+          border: 2px dotted blue;
           color: blue;
           margin: 0 1em;
           padding: 0.25em 1em;
@@ -21,17 +21,12 @@ class ExampleButton extends Component {
           position: relative;
         }
 
+        :host button:hover,
+        :host button:active,
         :host button:focus {
-          border-style: dotted;
-        }
-
-        :host button:active {
+          border-style: solid;
           top: 1px;
           left: 1px;
-        }
-
-        :host button:hover {
-          border-style: solid;
         }
 
         /* *************************************
@@ -49,7 +44,7 @@ class ExampleButton extends Component {
           font-size: var(--base-font-size);
           background: transparent;
           border-radius: 3px;
-          border: 2px solid blue;
+          border: 2px dotted blue;
           color: blue;
           margin: 0 1em;
           padding: 0.25em 1em;
@@ -57,17 +52,12 @@ class ExampleButton extends Component {
           position: relative;
         }
 
+        example-button button:hover,
+        example-button button:active,
         example-button button:focus {
-          border-style: dotted;
-        }
-
-        example-button button:active {
+          border-style: solid;
           top: 1px;
           left: 1px;
-        }
-
-        example-button button:hover {
-          border-style: solid;
         }
         /* ************************************* */
       </style>

--- a/examples/src/ts/styled/index.ts
+++ b/examples/src/ts/styled/index.ts
@@ -15,7 +15,7 @@ class ExampleButton extends Component {
           font-size: var(--base-font-size);
           background: transparent;
           border-radius: 3px;
-          border: 2px solid blue;
+          border: 2px dotted blue;
           color: blue;
           margin: 0 1em;
           padding: 0.25em 1em;
@@ -23,17 +23,12 @@ class ExampleButton extends Component {
           position: relative;
         }
 
+        :host button:hover,
+        :host button:active,
         :host button:focus {
-          border-style: dotted;
-        }
-
-        :host button:active {
+          border-style: solid;
           top: 1px;
           left: 1px;
-        }
-
-        :host button:hover {
-          border-style: solid;
         }
 
         /* *************************************
@@ -51,7 +46,7 @@ class ExampleButton extends Component {
           font-size: var(--base-font-size);
           background: transparent;
           border-radius: 3px;
-          border: 2px solid blue;
+          border: 2px dotted blue;
           color: blue;
           margin: 0 1em;
           padding: 0.25em 1em;
@@ -59,17 +54,12 @@ class ExampleButton extends Component {
           position: relative;
         }
 
+        example-button button:hover,
+        example-button button:active,
         example-button button:focus {
-          border-style: dotted;
-        }
-
-        example-button button:active {
+          border-style: solid;
           top: 1px;
           left: 1px;
-        }
-
-        example-button button:hover {
-          border-style: solid;
         }
         /* ************************************* */
       </style>

--- a/src/create-style.ts
+++ b/src/create-style.ts
@@ -1,10 +1,6 @@
-import { HTMLElementContent } from './types';
+import { HTMLElementContent, HTMLFragment } from './types';
+import { html } from './create-html';
 
-export const createStyle = (styleContent: HTMLElementContent): HTMLStyleElement => {
-  const styleElement = document.createElement('style');
-  styleElement.innerHTML = typeof styleContent === 'string'
-    ? styleContent
-    : styleContent.toString();
-
-  return styleElement;
-};
+export const createStyle = (styleContent: HTMLElementContent): HTMLFragment => html`
+  <style>${typeof styleContent === 'string' ? styleContent : styleContent.toString()}</style>
+`;

--- a/src/internal-types.ts
+++ b/src/internal-types.ts
@@ -24,7 +24,7 @@ export interface ComponentPrototype extends Function {
   render: RenderFuntion;
   rendered: () => void;
   emit: <TEvent>(name: string, detail?: TEvent, addPrefix?: boolean) => boolean;
-  createStyle: (styleContent: HTMLElementContent) => HTMLStyleElement;
+  createStyle: (styleContent: HTMLElementContent) => HTMLFragment;
   setState: (state: object | ((state: object) => object)) => void;
 }
 

--- a/tests/style.spec.ts
+++ b/tests/style.spec.ts
@@ -1,15 +1,22 @@
+import { HTMLElementContent } from '../src/types';
 import { createStyle } from '../src/create-style';
 
-describe('#createStyle', (): void => {
-  beforeEach((): void => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    document.createElement = jest.fn((): any => ({ innerHTML: undefined }));
-  });
+jest.mock('../src/create-html', (): object => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  html: jest.fn((template: TemplateStringsArray, ...args: any[]) => template
+    .reduce((accumulator, hole, index) => `${accumulator}${hole}${args.length - 1 >= index ? args[index] : ''}`, '')),
+}));
 
+const createStyleRetyped = (style: HTMLElementContent): string => (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  createStyle(style) as any as string
+);
+
+describe('#createStyle', (): void => {
   describe('is given a string', (): void => {
     it('sets innerHTML to it', (): void => {
-      const result = createStyle('mock-style');
-      expect(result.innerHTML).toBe('mock-style');
+      const result = createStyleRetyped('mock-style').trim();
+      expect(result).toBe('<style>mock-style</style>');
     });
   });
 
@@ -17,8 +24,9 @@ describe('#createStyle', (): void => {
     it('sets innerHTML to the result of ".toString()"', (): void => {
       const styles = {};
       styles.toString = (): string => 'mock-style';
-      const result = createStyle(styles);
-      expect(result.innerHTML).toBe('mock-style');
+
+      const result = createStyleRetyped(styles).trim();
+      expect(result).toBe('<style>mock-style</style>');
     });
   });
 });


### PR DESCRIPTION
No breaking changes.

Just replaces how the style element gets built. By using the `html` function, we avoid re-rendering the style component everytime the component renders - should avoid some repainting on older browsers.