### PR TITLE
Feature: Custom element events

### DIFF
--- a/examples/src/js/nested/child.js
+++ b/examples/src/js/nested/child.js
@@ -1,11 +1,21 @@
 import Component from '@biotope/element';
 
 export class ExampleChild extends Component {
+  constructor() {
+    super(false);
+  }
+
   render() {
     return this.html`
       <p>parent prop: ${this.props.text}</p>
       <p>my prop: ${this.props.anotherText}</p>
     `;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  rendered() {
+    // eslint-disable-next-line no-console
+    console.log('CHILD: elements are in the DOM');
   }
 }
 

--- a/examples/src/js/nested/index.html
+++ b/examples/src/js/nested/index.html
@@ -13,4 +13,10 @@
     <example-parent text="Web components rock!!"></example-parent>
   </body>
 
+  <script>
+    document.querySelector('example-parent').addEventListener('rendered', function() {
+      console.log('done rendering');
+    });
+  </script>
+
 </html>

--- a/examples/src/js/nested/index.js
+++ b/examples/src/js/nested/index.js
@@ -2,6 +2,10 @@ import Component from '@biotope/element';
 import { ExampleChild } from './child';
 
 export class ExampleParent extends Component {
+  constructor() {
+    super(false);
+  }
+
   render() {
     return this.html`
       <div>
@@ -11,6 +15,12 @@ export class ExampleParent extends Component {
         />
       </div>
     `;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  rendered() {
+    // eslint-disable-next-line no-console
+    console.log('PARENT: elements are in the DOM');
   }
 }
 

--- a/examples/src/ts/nested/child.ts
+++ b/examples/src/ts/nested/child.ts
@@ -13,10 +13,20 @@ export class ExampleChild extends Component<ExampleChildProps> {
     'another-text',
   ];
 
+  public constructor() {
+    super(false);
+  }
+
   public render(): HTMLFragment {
     return this.html`
       <p>parent prop: ${this.props.text}</p>
       <p>my prop: ${this.props.anotherText}</p>
     `;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  public rendered(): void {
+    // eslint-disable-next-line no-console
+    console.log('CHILD: elements are in the DOM');
   }
 }

--- a/examples/src/ts/nested/index.html
+++ b/examples/src/ts/nested/index.html
@@ -13,4 +13,10 @@
     <example-parent text="Web components rock!!"></example-parent>
   </body>
 
+  <script>
+    document.querySelector('example-parent').addEventListener('rendered', function() {
+      console.log('done rendering');
+    });
+  </script>
+
 </html>

--- a/examples/src/ts/nested/index.ts
+++ b/examples/src/ts/nested/index.ts
@@ -14,6 +14,10 @@ export class ExampleParent extends Component<ExampleParentProps> {
     ExampleChild as typeof Component,
   ];
 
+  public constructor() {
+    super(false);
+  }
+
   public render(): HTMLFragment {
     return this.html`
       <div>
@@ -23,6 +27,12 @@ export class ExampleParent extends Component<ExampleParentProps> {
         />
       </div>
     `;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  public rendered(): void {
+    // eslint-disable-next-line no-console
+    console.log('PARENT: elements are in the DOM');
   }
 }
 

--- a/src/create-renders.ts
+++ b/src/create-renders.ts
@@ -1,0 +1,31 @@
+import { ComponentInstance, RenderFunction } from './internal-types';
+import { HTMLFragment } from './types';
+
+const emitRendered = (context: ComponentInstance, elements: ComponentInstance[]): void => {
+  // eslint-disable-next-line no-underscore-dangle
+  if (!elements.length || !elements.some((element) => !element.__rendered)) {
+    // eslint-disable-next-line no-underscore-dangle,no-param-reassign
+    context.__rendered = true;
+    context.emit('rendered', undefined, true);
+  } else {
+    setTimeout(() => emitRendered(context, elements));
+  }
+};
+
+export const rendered = (context: ComponentInstance): void => {
+  context.rendered();
+
+  const elements = ([...(context.shadowRoot || context).querySelectorAll('*')] as ComponentInstance[])
+    // eslint-disable-next-line no-underscore-dangle
+    .filter((element) => typeof element.__rendered === 'boolean');
+
+  emitRendered(context, elements);
+};
+
+export const render = (
+  context: ComponentInstance, renderFunction: RenderFunction,
+): HTMLFragment => {
+  // eslint-disable-next-line no-underscore-dangle,no-param-reassign
+  context.__rendered = false;
+  return renderFunction();
+};

--- a/src/emit.ts
+++ b/src/emit.ts
@@ -1,16 +1,13 @@
 import { ComponentInstance } from './internal-types';
 
 export const emit = <T>(
-  context: ComponentInstance, name: string, detail: T, addPrefix: boolean,
+  context: ComponentInstance, name: string, detail: T, singleEmit: boolean,
 ): boolean => {
   if (!name) {
     throw Error('No event name defined. Please provide a name.');
   }
-  return context.dispatchEvent(new CustomEvent(
-    `${addPrefix ? `${context.constructor.componentName}-` : ''}${name}`,
-    {
-      bubbles: true,
-      ...(detail !== undefined && { detail }),
-    },
-  ));
+  return context.dispatchEvent(new CustomEvent(name, {
+    bubbles: !singleEmit,
+    ...(detail !== undefined && { detail }),
+  }));
 };

--- a/src/internal-types.ts
+++ b/src/internal-types.ts
@@ -20,6 +20,7 @@ export interface ComponentPrototype extends Function {
   html: Renderer<HTMLFragment>;
   created: () => void;
   connectedCallback: () => void;
+  disconnectedCallback: () => void;
   attributeChangedCallback: (name: string, oldValue: PropValue, newValue: PropValue) => void;
   render: RenderFunction;
   rendered: () => void;

--- a/src/internal-types.ts
+++ b/src/internal-types.ts
@@ -24,7 +24,7 @@ export interface ComponentPrototype extends Function {
   attributeChangedCallback: (name: string, oldValue: PropValue, newValue: PropValue) => void;
   render: RenderFunction;
   rendered: () => void;
-  emit: <TEvent>(name: string, detail?: TEvent, addPrefix?: boolean) => boolean;
+  emit: <TEvent>(name: string, detail?: TEvent, singleEmit?: boolean) => boolean;
   createStyle: (styleContent: HTMLElementContent) => HTMLFragment;
   setState: (state: object | ((state: object) => object)) => void;
 }
@@ -41,5 +41,6 @@ export interface ComponentInstance extends RuntimeComponent {
   __currentState: object;
   __html: Renderer<HTMLFragment>;
   __created: boolean;
+  __rendered: boolean;
   __attributeChangedCallbackStack: (() => void)[];
 }

--- a/src/register.ts
+++ b/src/register.ts
@@ -67,19 +67,39 @@ export const register = (context: ComponentType, silent: boolean): boolean => {
 
     instance.__created = true;
     instance.render();
+    instance.emit('connected');
   };
 
   const originalAttributeChangedCallback = context.prototype.attributeChangedCallback;
 
   context.prototype.attributeChangedCallback = function (...args): void {
     const instance = (this as ComponentInstance);
-    const callFunction = (): void => originalAttributeChangedCallback.bind(instance)(...args);
+    const callFunction = (): void => {
+      originalAttributeChangedCallback.bind(instance)(...args);
+      instance.emit('attributechanged');
+    };
 
     if (instance.__created) {
       callFunction();
     } else {
       instance.__attributeChangedCallbackStack.unshift(callFunction);
     }
+  };
+
+  const originalRendered = context.prototype.rendered;
+
+  context.prototype.disconnectedCallback = function (): void {
+    const instance = (this as ComponentInstance);
+    originalRendered.bind(instance)();
+    instance.emit('rendered');
+  };
+
+  const originalDisconnectedCallback = context.prototype.disconnectedCallback;
+
+  context.prototype.disconnectedCallback = function (): void {
+    const instance = (this as ComponentInstance);
+    originalDisconnectedCallback.bind(instance)();
+    instance.emit('disconnected');
   };
 
   customElements.define(context.componentName, context);

--- a/src/register.ts
+++ b/src/register.ts
@@ -67,7 +67,7 @@ export const register = (context: ComponentType, silent: boolean): boolean => {
 
     instance.__created = true;
     instance.render();
-    instance.emit('connected');
+    instance.emit('connected', undefined, true);
   };
 
   const originalAttributeChangedCallback = context.prototype.attributeChangedCallback;
@@ -76,7 +76,7 @@ export const register = (context: ComponentType, silent: boolean): boolean => {
     const instance = (this as ComponentInstance);
     const callFunction = (): void => {
       originalAttributeChangedCallback.bind(instance)(...args);
-      instance.emit('attributechanged');
+      instance.emit('attributechanged', undefined, true);
     };
 
     if (instance.__created) {
@@ -86,20 +86,12 @@ export const register = (context: ComponentType, silent: boolean): boolean => {
     }
   };
 
-  const originalRendered = context.prototype.rendered;
-
-  context.prototype.rendered = function (): void {
-    const instance = (this as ComponentInstance);
-    originalRendered.bind(instance)();
-    instance.emit('rendered');
-  };
-
   const originalDisconnectedCallback = context.prototype.disconnectedCallback;
 
   context.prototype.disconnectedCallback = function (): void {
     const instance = (this as ComponentInstance);
     originalDisconnectedCallback.bind(instance)();
-    instance.emit('disconnected');
+    instance.emit('disconnected', undefined, true);
   };
 
   customElements.define(context.componentName, context);

--- a/src/register.ts
+++ b/src/register.ts
@@ -88,7 +88,7 @@ export const register = (context: ComponentType, silent: boolean): boolean => {
 
   const originalRendered = context.prototype.rendered;
 
-  context.prototype.disconnectedCallback = function (): void {
+  context.prototype.rendered = function (): void {
     const instance = (this as ComponentInstance);
     originalRendered.bind(instance)();
     instance.emit('rendered');

--- a/tests/create-renders.spec.ts
+++ b/tests/create-renders.spec.ts
@@ -1,0 +1,106 @@
+import { HTMLFragment } from '../src/types';
+import { ComponentInstance } from '../src/internal-types';
+import { render, rendered } from '../src/create-renders';
+
+describe('#render', () => {
+  const fragment: HTMLFragment = {
+    type: 'html',
+    args: undefined,
+  };
+  let component;
+  let result;
+
+  beforeEach(() => {
+    component = {};
+    result = render(component, jest.fn(() => fragment));
+  });
+
+  it('resets the rendered property', () => {
+    // eslint-disable-next-line no-underscore-dangle
+    expect((component as ComponentInstance).__rendered).toBe(false);
+  });
+
+  it('resets the rendered property', () => {
+    // eslint-disable-next-line no-underscore-dangle
+    expect(result).toBe(fragment);
+  });
+});
+
+describe('#rendered', () => {
+  let component;
+
+  beforeEach(() => {
+    component = {
+      shadowRoot: {
+        querySelectorAll: jest.fn(() => []),
+      },
+      rendered: jest.fn(),
+      emit: jest.fn(),
+    };
+  });
+
+  it('calls the original rendered once', () => {
+    rendered(component);
+    expect(component.rendered.mock.calls).toHaveLength(1);
+    expect(component.rendered.mock.calls[0]).toEqual([]);
+  });
+
+  describe('element has shadowRoot', () => {
+    describe('has no children', () => {
+      beforeEach(() => {
+        rendered(component);
+      });
+
+      it('calls the shadowRoot querySelectorAll', () => {
+        expect(component.shadowRoot.querySelectorAll.mock.calls).toHaveLength(1);
+        expect(component.shadowRoot.querySelectorAll.mock.calls[0]).toEqual(['*']);
+      });
+
+      it('marks the element as rendered', () => {
+        // eslint-disable-next-line no-underscore-dangle
+        expect((component as ComponentInstance).__rendered).toBe(true);
+      });
+
+      it('emits a rendered event', () => {
+        expect(component.emit.mock.calls).toHaveLength(1);
+        expect(component.emit.mock.calls[0]).toEqual(['rendered', undefined, true]);
+      });
+    });
+
+    describe('has children', () => {
+      let innerElements;
+
+      beforeEach(() => {
+        innerElements = [{}, { __rendered: false }];
+        component.shadowRoot.querySelectorAll = jest.fn(() => innerElements);
+        rendered(component);
+      });
+
+      it('waits until children are rendered', (done) => setTimeout(() => {
+        // eslint-disable-next-line no-underscore-dangle
+        expect(component.shadowRoot.querySelectorAll()[1].__rendered).toBe(false);
+        // eslint-disable-next-line no-underscore-dangle
+        innerElements[1].__rendered = true;
+
+        setTimeout(() => {
+          // eslint-disable-next-line no-underscore-dangle
+          expect(component.shadowRoot.querySelectorAll()[1].__rendered).toBe(true);
+          done();
+        });
+      }, 100));
+    });
+  });
+
+  describe('element does not have shadowRoot', () => {
+    beforeEach(() => {
+      component.querySelectorAll = component.shadowRoot.querySelectorAll;
+      component.shadowRoot = undefined;
+      rendered(component);
+    });
+
+    it('calls the component querySelectorAll', () => {
+      expect(component.querySelectorAll.mock.calls).toHaveLength(1);
+      expect(component.querySelectorAll.mock.calls[0]).toEqual(['*']);
+    });
+  });
+});

--- a/tests/emit.spec.ts
+++ b/tests/emit.spec.ts
@@ -33,6 +33,10 @@ describe('#emit', () => {
       it('emits a custom event without detail', () => {
         expect(customEvent.detail).toBeUndefined();
       });
+
+      it('emits a custom event that bubbles', () => {
+        expect(customEvent.bubbles).toBe(true);
+      });
     });
 
     describe('is given', () => {
@@ -49,10 +53,14 @@ describe('#emit', () => {
       it('emits a custom event with bubbles', () => {
         expect(customEvent.bubbles).toBeTruthy();
       });
+
+      it('emits a custom event that bubbles', () => {
+        expect(customEvent.bubbles).toBe(true);
+      });
     });
   });
 
-  describe('addPrefix is true', () => {
+  describe('singleEmit is true', () => {
     let customEvent: CustomEvent;
 
     beforeEach(() => {
@@ -62,12 +70,15 @@ describe('#emit', () => {
     });
 
     it('emits a custom event with a prefixed name', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect(customEvent.type).toBe(`${(element.constructor as any).componentName}-mock-name`);
+      expect(customEvent.type).toBe('mock-name');
     });
 
     it('emits a custom event with detail', () => {
       expect(customEvent.detail).toBe('mock-detail');
+    });
+
+    it('emits a custom event that does not bubble', () => {
+      expect(customEvent.bubbles).toBe(false);
     });
   });
 });


### PR DESCRIPTION
**New Feature:**
- automatic "connected", "disconnected", "attributechanged" and "rendered" events
  - "rendered" **hook** still fires right after the component DOM is updated (i.e. does not wait for children to render themselves)
  - "rendered" **event** fires only when all children of the component are rendered (i.e. waits for children to render themselves) - useful for pre-renderers for example
  - the new events do not bubble up the DOM - i.e. if the parent of a component has an event listener for "connected" on himself, it will not be triggered by the child emitting a "connected" event  - useful for not getting several "connected" events triggered on one parent component

Basically now we can do this out of the box:
```html
<my-button onconnected="..." onrendered="..."></my-button>
```

**Breaking changes:**
- `emit` function's third argument changed to `singleEmit` - `addPrefix` removed
  - this is because `addPrefix` can be achieved by adding it to the first parameter of the `emit`
  - and because it's more useful to send a "do not bubble" parameter instead
