### PR TITLE
Bugfix: No shadow + no render = overriding initial content

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -102,7 +102,7 @@ export default abstract class Component<TProps = object, TState = object> extend
   }
 
   public render(): HTMLFragment {
-    return this.html``;
+    return null;
   }
 
   /* istanbul ignore next */

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,7 @@ export default abstract class Component<TProps = object, TState = object> extend
     return attributeChangedCallback(this as any, name, previous, current);
   }
 
+  // eslint-disable-next-line class-methods-use-this
   public render(): HTMLFragment {
     return null;
   }


### PR DESCRIPTION
```html
<my-button>
  <p>Hello World!</p>
</my-button>
```
```javascript
class MyButton extends Component {
  constructor() {
    super(false);
  }
}
MyButton.register();
```

Result was:
```html
<my-button>
</my-button>
```

With the fix, the result is as expected:
```html
<my-button>
  <p>Hello World!</p>
</my-button>
```